### PR TITLE
p-header__hamburgerのクラスを削除

### DIFF
--- a/src/ejs/component/_c-hamburger.ejs
+++ b/src/ejs/component/_c-hamburger.ejs
@@ -1,3 +1,3 @@
-<button type="button" class="p-header__hamburger c-hamburger js-hamburger">
+<button type="button" class="c-hamburger js-hamburger">
   <span class="c-hamburger__line"></span>
 </button>


### PR DESCRIPTION
全体MTGで、ひろきさんからご指摘あり削除。
p-header__hamburgerは呼び出し元に記載する