### PR TITLE
表示確認と参照ようのファイルを追加

### DIFF
--- a/src/ejs/index.ejs
+++ b/src/ejs/index.ejs
@@ -2,24 +2,8 @@
 <html lang="ja">
 <%- include('./common/_head') %>
   <body>
-    <%- include('./common/_top-header') %>
-    <%- include('./common/_p-header-nav') %>
-    
-    <%- include('./component/_c-btn',{text:'詳しく見る', link:'#', btntype:'normal'}) %>
-    <%- include('./component/_c-btn',{text:'すべて見る', link:'#', btntype:'pcSmall'}) %>
-    <%- include('./component/_c-btn',{text:'送信', link:'#', btntype:'submit'}) %>
-      <%- include('./component/_c-logo') %>
-      <%- include('./component/_c-hamburger') %>
-
-    <%- include('./common/_footer') %>
-
-
-    <% for (var i=0; i < 4; i++) { %>
-      <%- include('./component/_c-btn',{text:'これはテストです', link:'#', btntype:'normal'}) %>
-      <% } %>
-
-<div class="c-top-btn">
-  <a href="#"></a>
-</div>
+  <%#
+  元々のコードを残しておくと、エラーが出てしまうため削除しました。
+  %>
   </body>
 </html>

--- a/src/ejs/toshi.ejs
+++ b/src/ejs/toshi.ejs
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="ja">
+<%- include('./common/_head') %>
+  <body>
+
+    <p>component/_c-logo</p>
+    <%- include('./component/_c-logo') %>
+    
+    <p>component/_c-top-btn</p>
+    <%- include('./component/_c-top-btn') %>
+
+    <%#
+     下記パーツはまだマージしていないので、エラーが出ないようにコメントアウトしています
+     パーツ完成後に、"%#" → "%-"に修正
+     %>
+    
+    <p>project/_p-category</p>
+    <%# include('./project/_p-category') %>
+    
+    <p>project/_p-pager</p>
+    <%# include('./project/_p-pager') %>
+
+
+    
+  </body>
+</html>

--- a/src/ejs/yoshi.ejs
+++ b/src/ejs/yoshi.ejs
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ja">
+<%- include('./common/_head') %>
+  <body>
+    <p>component/_c-btn btntype:'normal'</p>
+    <%- include('./component/_c-btn',{text:'詳しく見る', link:'#', btntype:'normal'}) %>
+
+    <p>component/_c-btn btntype:'pcSmall'</p>
+    <%- include('./component/_c-btn',{text:'すべて見る', link:'#', btntype:'pcSmall'}) %>
+
+    <p>component/_c-btn btntype:'submit'</p>
+    <%- include('./component/_c-btn',{text:'送信', link:'#', btntype:'submit'}) %>
+
+    <p>component/_c-hamburger</p>
+    <%- include('./component/_c-hamburger') %>
+    
+    <p>common/_p-header-nav</p>
+    <%- include('./common/_p-header-nav') %>
+
+    <p>common/_footer</p>
+    <%- include('./common/_footer') %>
+
+
+
+  <a href="#"></a>
+</div>
+  </body>
+</html>


### PR DESCRIPTION
### 表示確認と参照用のファイルを追加
ひとしさん → toshi.ejs
よしあき → yoshi.ejs

表示確認をするときには、index.ejsではなく上記ファイルを使う

urlの末尾に/yoshi.htmlを追加して
例　http://localhost:3000/yoshi.html
のようにすると確認できます。

相手が作ったパーツを参照するときにもこれがあると便利かと思います。

### index.ejs
初期状態のままindex.ejsを置いておくとエラーが出てしまうので、
bodyの中身を削除しました。

